### PR TITLE
Fix axios example script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # axios-example
 
-axios provides an easy way to send HTTP request like what request module did.
+axios provides an easy way to send HTTP requests like what the `request` module does.
 
-The difference between axios and request is that axios support ES6 Promise itself.  
-Howevere, request need you to install another module to do that.
+The difference between axios and request is that axios supports ES6 Promise natively.
+However, request requires you to install an additional module to do that.
 
 ## Installation :
 
 Just type the following command to install it.
-```=bash
+```bash
 yarn add axios
 // or
 npm install axios --save
 ```
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "axios-example",
   "version": "1.0.0",
   "description": "A simple example for axios, which provides nodejs ability to send HTTP request like request module.",
-  "main": "index.js",
+  "main": "src/index.js",
   "repository": "https://git.idsl.pw/Hakalon/axios-example.git",
   "author": "Steve Lai <tf4ewg@gmail.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,30 @@
 const axios = require('axios');
 const JsSHA = require('jssha');
 
+function getAuthorizationHeader() {
+  const appID = '31c5632cc08d4421abf734566fd50ed2';
+  const appKey = 'CNaXup9EDeew3oyoa8N8CWdE2ZI';
+  const GMTString = new Date().toUTCString();
+  const shaObj = new JsSHA('SHA-1', 'TEXT');
+
+  shaObj.setHMACKey(appKey, 'TEXT');
+  shaObj.update(`x-date: ${GMTString}`);
+
+  const HMAC = shaObj.getHMAC('B64');
+  const authorization = `hmac username="${appID}", algorithm="hmac-sha1", headers="x-date", signature="${HMAC}"`;
+
+  // 若要減少傳輸可以再加上Accept-Encoding: 'gzip'，但使用時就必須額外做解壓縮的動作，否則會得到一串亂碼。
+  return {
+    Authorization: authorization, 'X-Date': GMTString
+  };
+}
+
 const headers = getAuthorizationHeader();
 const city = 'Taipei';
 const route = '912';
 
 const motcReqSender = axios.create({
-  baseURL: 'http://ptx.transportdata.tw/MOTC/v2/Bus/RealTimeByFrequency/City/',
+  baseURL: 'https://ptx.transportdata.tw/MOTC/v2/Bus/RealTimeByFrequency/City/',
   headers
 });
 
@@ -21,22 +39,3 @@ motcReqSender.get(`${city}/${route}?$top=1&$format=JSON`)
     console.log('There is something wrong: ');
     console.log(err);
   });
-
-// MOTC授權認證
-function getAuthorizationHeader() {
-  const appID = '31c5632cc08d4421abf734566fd50ed2';
-  const appKey = 'CNaXup9EDeew3oyoa8N8CWdE2ZI';
-  const GMTString = new Date().toGMTString();
-  const shaObj = new JsSHA('SHA-1', 'TEXT');
-
-  shaObj.setHMACKey(appKey, 'TEXT');
-  shaObj.update(`x-date: ${GMTString}`);
-
-  const HMAC = shaObj.getHMAC('B64');
-  const authorization = `hmac username="${appID}", algorithm="hmac-sha1", headers="x-date", signature="${HMAC}"`;
-
-  // 若要減少傳輸可以再加上Accept-Encoding: 'gzip'，但使用時就必須額外做解壓縮的動作，否則會得到一串亂碼。
-  return {
-    Authorization: authorization, 'X-Date': GMTString
-  };
-}


### PR DESCRIPTION
## Summary
- correct README typos and code block formatting
- point `main` to `src/index.js`
- use HTTPS and `toUTCString` in example script
- expose auth helper before it is used

## Testing
- `npx eslint src/index.js` *(fails: "npm warn Unknown env config 'http-proxy'")*
- `node src/index.js` *(fails: network error EPROTO)*

------
https://chatgpt.com/codex/tasks/task_e_68404de35f4c8329b3ad795c642b3bbe